### PR TITLE
List plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/marcobiedermann/gatsby-plugin-svg-sprite.git"
   },
-  "keywords": [],
+  "keywords": ["gatsby-plugin", "gatsby", "svg", "sprite"],
   "author": "Marco Biedermann",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search.

See https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310