### PR TITLE
gatsby-node.js: migrate to Gatsby v2

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,18 +1,26 @@
-exports.modifyWebpackConfig = ({ config }, options = {}) => {
-  config.loader('url-loader', {
-    test: /\.(jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
-    loader: 'url',
-    query: {
-      limit: 10000,
-      name: 'static/[name].[hash:8].[ext]',
-    },
+exports.onCreateWebpackConfig = ({ actions, loaders }, options = {}) => {
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.(jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
+          use: [
+            loaders.url({
+              limit: 10000,
+              name: 'static/[name].[hash:8].[ext]',
+            }),
+          ],
+        },
+        {
+          test: /\.svg$/,
+          use: [
+            {
+              loader: require.resolve('svg-sprite-loader'),
+              options,
+            },
+          ],
+        },
+      ]
+    }
   });
-
-  config.loader('svg-sprite', {
-    loader: 'svg-sprite-loader',
-    test: /\.svg$/,
-    query: options,
-  });
-
-  return config;
 };


### PR DESCRIPTION
The API to make changes to webpack was changed for v2:
https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-code-classlanguage-textmodifywebpackconfigcode-to-code-classlanguage-textoncreatewebpackconfigcode

Actually, my version still doesn't work but at least it generates the proper webpack config.